### PR TITLE
Implement modes/capabilities for Workspaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'dry-validation', '~> 1.5'
 
 gem 'excon'
 gem 'rack-cors'
+gem 'rack-attack'
 
 gem 'nokogiri', '>= 1.12.5'
 
@@ -42,8 +43,8 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 4.1.0'
-  gem 'rack-mini-profiler', '~> 2.0'
+  # gem 'web-console', '>= 4.1.0'
+  # gem 'rack-mini-profiler', '~> 2.0'
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,6 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     bcrypt (3.1.16)
-    bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -152,10 +151,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-attack (6.5.0)
+      rack (>= 1.0, < 3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-mini-profiler (2.3.3)
-      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.4.1)
@@ -212,11 +211,6 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.4)
       tzinfo (>= 1.0.0)
-    web-console (4.1.0)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -243,15 +237,14 @@ DEPENDENCIES
   pry
   pry-byebug
   puma (~> 5.0)
+  rack-attack
   rack-cors
-  rack-mini-profiler (~> 2.0)
   rails (~> 6.1, >= 6.1.4.1)
   redis
   rjob (~> 0.5)
   spring
   spyderweb!
   tzinfo-data
-  web-console (>= 4.1.0)
 
 BUNDLED WITH
    2.2.28

--- a/app/controllers/api_admin/workspaces_controller.rb
+++ b/app/controllers/api_admin/workspaces_controller.rb
@@ -78,10 +78,15 @@ class ApiAdmin::WorkspacesController < AdminApiController
   def workspace_for_serialization(ws)
     api_key = ws.api_keys.order(id: :desc).limit(1).where(expires_at: nil, deleted_at: nil).first
 
+    caps = ws.capabilities.map do |cap_id|
+      Workspace::REVERSE_CAPABILITIES[cap_id]
+    end
+
     {
       id: ws.public_uuid,
       name: ws.name,
       api_key_created_at: api_key&.created_at,
+      capabilities: caps,
       created_at: ws.created_at
     }
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -16,6 +16,22 @@ class ApiController < ApplicationController
   rescue_from Spyderweb::Kellogs::Cereal::CerealizationPageDataError, with: :fail_invalid_page!
   # rescue_from Spyderweb::Kellogs::Cereal::CerealizationClientError # TODO!
 
+  class << self
+    def requires_workspace_capability(*list)
+      before_action do
+        caps_met = list.any? { |cap| @workspace.has_capability?(cap) }
+        if !caps_met
+          render json: {
+            error: {
+              code: "workspace_not_allowed",
+              message: "This workspace does not allow this endpoint to be called"
+            }
+          }, status: 403
+        end
+      end
+    end
+  end
+
   protected
 
   def fail_not_found!

--- a/app/controllers/api_v1/bindings_controller.rb
+++ b/app/controllers/api_v1/bindings_controller.rb
@@ -4,6 +4,8 @@ class ApiV1::BindingsController < ApiController
   before_action :fetch_router, only: [:create]
   before_action :fetch_binding, only: [:topics, :show]
 
+  requires_workspace_capability :receiver
+
   def create
     existing_rb = @workspace.receiver_bindings
       .find_by(router_id: @router.id)

--- a/app/controllers/api_v1/keys_controller.rb
+++ b/app/controllers/api_v1/keys_controller.rb
@@ -4,6 +4,8 @@ class ApiV1::KeysController < ApiController
   before_action :fetch_key, only: [:show, :update]
   before_action :process_input, only: [:update, :create]
 
+  requires_workspace_capability :receiver, :sender
+
   KEY_SIZES = {
     hmac_sha1: 64,
     hmac_sha256: 64,

--- a/app/controllers/api_v1/publisher_controller.rb
+++ b/app/controllers/api_v1/publisher_controller.rb
@@ -14,6 +14,7 @@ class ApiV1::PublisherController < ApiController
   #   rule(:allowed_topics).validate(:uuid_or_names)
   #   rule(:custom_attributes).validate(:custom_json)
   # end
+  requires_workspace_capability :sender
 
   def publish
     data = body_obj['data'].symbolize_keys

--- a/app/controllers/api_v1/routers_controller.rb
+++ b/app/controllers/api_v1/routers_controller.rb
@@ -4,6 +4,8 @@ class ApiV1::RoutersController < ApiController
   before_action :fetch_router, only: [:show, :update]
   before_action :process_input, only: [:update, :create]
 
+  requires_workspace_capability :sender
+
   def index
     render_collection_paginated(@workspace.routers)
   end

--- a/app/controllers/api_v1/subscriptions_controller.rb
+++ b/app/controllers/api_v1/subscriptions_controller.rb
@@ -4,6 +4,8 @@ class ApiV1::SubscriptionsController < ApiController
   before_action :fetch_subscription, only: [:show, :update]
   before_action :process_subscriptions_input, only: [:update, :create]
 
+  requires_workspace_capability :receiver
+
   def index
     render_collection_paginated(@workspace.subscriptions)
   end

--- a/app/controllers/api_v1/tags_controller.rb
+++ b/app/controllers/api_v1/tags_controller.rb
@@ -4,6 +4,8 @@ class ApiV1::TagsController < ApiController
   before_action :fetch_tag, only: [:show, :update]
   before_action :process_input, only: [:update, :create]
 
+  requires_workspace_capability :sender
+
   def index
     render_collection_paginated(@workspace.tags)
   end

--- a/app/controllers/api_v1/topics_controller.rb
+++ b/app/controllers/api_v1/topics_controller.rb
@@ -4,6 +4,8 @@ class ApiV1::TopicsController < ApiController
   before_action :fetch_topic, only: [:show, :update]
   before_action :process_input, only: [:update, :create]
 
+  requires_workspace_capability :sender
+
   def create
     @topic = Topic.new
     @topic.attributes = @processor.values_for_model

--- a/app/controllers/api_v1/webhook_definitions_controller.rb
+++ b/app/controllers/api_v1/webhook_definitions_controller.rb
@@ -4,6 +4,8 @@ class ApiV1::WebhookDefinitionsController < ApiController
   before_action :fetch_webhook_definition, only: [:show, :update]
   before_action :process_input, only: [:update, :create]
 
+  requires_workspace_capability :sender
+
   def index
     render_collection_paginated(@workspace.webhook_definitions)
   end

--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -2,6 +2,15 @@
 class Workspace < ApplicationRecord
   include HasPublicId
 
+  CAPABILITIES = {
+    sender: 1,
+    receiver: 2,
+  }.freeze
+
+  REVERSE_CAPABILITIES = CAPABILITIES.map do |k, v|
+    [v, k]
+  end.to_h.freeze
+
   has_many :topics
   has_many :webhook_definitions
   has_many :routers
@@ -10,4 +19,19 @@ class Workspace < ApplicationRecord
   has_many :receiver_bindings
   has_many :subscriptions
   has_many :api_keys
+
+  def has_capability?(name)
+    cap_id = CAPABILITIES.fetch(name)
+    capabilities.include?(cap_id)
+  end
+
+  def set_capability(name, active)
+    cap_id = CAPABILITIES.fetch(name)
+
+    if active
+      self.capabilities = (capabilities + [cap_id]).uniq
+    else
+      self.capabilities = capabilities - [cap_id]
+    end
+  end
 end

--- a/app/services/provisioner/receiver_workspace_provisioner.rb
+++ b/app/services/provisioner/receiver_workspace_provisioner.rb
@@ -28,6 +28,7 @@ class Provisioner::ReceiverWorkspaceProvisioner
 
   def create_workspace
     @workspace = Workspace.new(name: @workspace_name)
+    @workspace.set_capability(:receiver, true)
 
     @entities << @workspace
   end

--- a/app/services/provisioner/sender_workspace_provisioner.rb
+++ b/app/services/provisioner/sender_workspace_provisioner.rb
@@ -32,6 +32,7 @@ class Provisioner::SenderWorkspaceProvisioner
 
   def create_workspace
     @workspace = Workspace.new(name: @workspace_name)
+    @workspace.set_capability(:sender, true)
 
     @entities << @workspace
   end

--- a/config/conf.development.yml
+++ b/config/conf.development.yml
@@ -6,8 +6,7 @@ database:
   name: api2_development
 admin:
   enabled: true
-  allow_from:
-    - '127.0.0.0/8'
+  allow_from: '127.0.0.0/8,[::1]/128'
   auth_token: fDyRbfutO4nE5VvzYs4bdhPsUdn0Z6ECdbwXMXkkthGUNr6c
 app:
   webapp_base_url: ""

--- a/config/conf.production.yml
+++ b/config/conf.production.yml
@@ -7,7 +7,7 @@ database:
   port: 5432
 admin:
   enabled: false
-  allow_from: []
+  allow_from: '127.0.0.0/8,[::1]/128'
   auth_token: ''
 app:
   webapp_base_url: "http://localhost:3006"

--- a/config/initializers/admin_api_protection.rb
+++ b/config/initializers/admin_api_protection.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+if Comff.get_bool!("admin.enabled")
+  has_error = false
+
+  def err(msg)
+    Rails.logger.error(msg)
+    puts("\nPANIC: #{msg}\n")
+  end
+
+  if Comff.get_str("admin.allow_from").empty?
+    err("The configuration admin.allow_from cannot be empty. " +
+      "See https://webhooks.uno/docs/installation for possible values. Aborting bootstrap.")
+    has_error = true
+  end
+
+  if Comff.get_str("admin.auth_token").empty?
+    err("The configuration admin.auth_token cannot be empty. " +
+      "When admin is enabled, an authentication token must be present. Aborting bootstrap.")
+    has_error = true
+  end
+
+  if has_error
+    err("The admin API configuration was left unsafe. Please fix the errors above to continue." +
+      " The boot process will now be aborted.")
+
+    exit(1)
+  end
+
+  allowed_ips = Comff.get_str!("admin.allow_from").split(',').map do |mask|
+    mask = mask.strip
+    IPAddr.new(mask)
+  end
+
+  Rack::Attack.safelist("Admin API safelist") do |req|
+    next true unless req.path.start_with?('/admin/')
+
+    allowed_ips.any? { |mask| mask.include?(req.ip) }
+  end
+
+  Rack::Attack.blocklist("Admin API blocklist") do |req|
+    next false unless req.path.start_with?('/admin/')
+
+    true
+  end
+end

--- a/db/migrate/20211203221857_add_usage_to_workspaces.rb
+++ b/db/migrate/20211203221857_add_usage_to_workspaces.rb
@@ -1,0 +1,5 @@
+class AddUsageToWorkspaces < ActiveRecord::Migration[6.1]
+  def change
+    add_column :workspaces, :capabilities, 'integer[]', default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_23_120938) do
+ActiveRecord::Schema.define(version: 2021_12_03_221857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -184,6 +184,7 @@ ActiveRecord::Schema.define(version: 2021_10_23_120938) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "capabilities", default: [], array: true
     t.index ["name"], name: "index_workspaces_on_name", unique: true
     t.index ["public_id"], name: "index_workspaces_on_public_id", unique: true
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180526477

Make it possible for Workspaces have a specific function. For instance, if a Workspace doesn't have the "sender" capability, it can't use sender endpoints such as publishing webhooks. Likewise for the "receiver" capability.

This was previously known as "consumer mode".